### PR TITLE
Fix frozen string error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.gem
 _site/
 Gemfile.lock
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ To use admonitions in your markdown files, simply add the following syntax:
 > [!WARNING]  
 > Critical content demanding immediate user attention due to potential risks.
 
-> [!CAUTION]
-> Negative potential consequences of an action.
+  > [!CAUTION]
+  > Negative potential consequences of an action.
+  > Opportunity to provide more context.
 ```
 
 > [!NOTE]
@@ -59,8 +60,9 @@ To use admonitions in your markdown files, simply add the following syntax:
 > [!WARNING]  
 > Critical content demanding immediate user attention due to potential risks.
 
-> [!CAUTION]
-> Negative potential consequences of an action.
+  > [!CAUTION]
+  > Negative potential consequences of an action.
+  > Opportunity to provide more context.
 
 #### Custom titles
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ To use admonitions in your markdown files, simply add the following syntax:
 > [!IMPORTANT]  
 > Crucial information necessary for users to succeed.
 
-> [!WARNING]  
-> Critical content demanding immediate user attention due to potential risks.
+  > [!WARNING]  
+  > Critical content demanding immediate
+  > user attention due to potential risks.
 
-  > [!CAUTION]
-  > Negative potential consequences of an action.
-  > Opportunity to provide more context.
+> [!CAUTION]
+> Negative potential consequences of an action.
+> Opportunity to provide more context.
 ```
 
 > [!NOTE]
@@ -57,12 +58,13 @@ To use admonitions in your markdown files, simply add the following syntax:
 > [!IMPORTANT]  
 > Crucial information necessary for users to succeed.
 
-> [!WARNING]  
-> Critical content demanding immediate user attention due to potential risks.
+  > [!WARNING]  
+  > Critical content demanding immediate
+  > user attention due to potential risks.
 
-  > [!CAUTION]
-  > Negative potential consequences of an action.
-  > Opportunity to provide more context.
+> [!CAUTION]
+> Negative potential consequences of an action.
+> Opportunity to provide more context.
 
 #### Custom titles
 

--- a/README.md
+++ b/README.md
@@ -185,4 +185,6 @@ for details.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit issues or pull requests.
+
+> [!TIP]
+> Contributions are welcome! Please feel free to submit issues or pull requests.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The following admonitions are supported:
 To use admonitions in your markdown files, simply add the following syntax:
 
 ```markdown
-> [!NOTE]  
+> [!NOTE]
 > Highlights information that users should take into account, even when skimming.
+> And supports multi-line text.
 
 > [!TIP]
 > Optional information to help a user be more successful.
@@ -45,8 +46,9 @@ To use admonitions in your markdown files, simply add the following syntax:
 > Negative potential consequences of an action.
 ```
 
-> [!NOTE]  
+> [!NOTE]
 > Highlights information that users should take into account, even when skimming.
+> And supports multi-line text.
 
 > [!TIP]
 > Optional information to help a user be more successful.

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -96,7 +96,7 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:>.*\n?)*)/) do
+      doc.content.gsub!(/^>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:>.*\n?)*)/) do
         type = ::Regexp.last_match(1).downcase
         if ::Regexp.last_match(2).strip.length > 0
           title = ::Regexp.last_match(2).strip

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -96,7 +96,7 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/^>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:>.*\n?)*)/) do
+      doc.content.gsub!(/^\s*>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\s*>\s*[^\n]*(?:\n|$))(?:(?!\s*>\s*\[!)\s*>\s*[^\n]*(?:\n|$))*)/) do
         type = ::Regexp.last_match(1).downcase
         if ::Regexp.last_match(2).strip.length > 0
           title = ::Regexp.last_match(2).strip
@@ -107,7 +107,8 @@ module JekyllGFMAdmonitions
         icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
         Jekyll.logger.debug 'GFMA:', "Converting #{type} admonition."
 
-        admonition_html(type, title, text, icon)
+        text_with_breaks = text.chomp.gsub(/\n/, "  \n")  # Remove trailing newline and add two spaces before remaining newlines
+        admonition_html(type, title, text_with_breaks, icon)
       end
     end
 

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -73,6 +73,9 @@ module JekyllGFMAdmonitions
     end
 
     def process_doc(doc)
+      # If the content is frozen, we need to duplicate it so that we can modify it
+      doc.content = doc.content.dup unless doc.content.frozen?
+
       code_blocks = []
       # Temporarily replace code blocks by a tag, so that we don't process any admonitions
       # inside of code blocks.

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -99,21 +99,16 @@ module JekyllGFMAdmonitions
       doc.content.gsub!(/^(\s*)>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1\s*>\s*[^\n]*(?:\n|$))(?:(?!\s*>\s*\[!)\1\s*>\s*[^\n]*(?:\n|$))*)/) do
         initial_indent = ::Regexp.last_match(1)
         type = ::Regexp.last_match(2).downcase
-        if ::Regexp.last_match(3).strip.length > 0
-          title = ::Regexp.last_match(3).strip
-        else
-          title = type.capitalize
-        end
-        
-        # Remove the consistent indentation and blockquote markers from each line
+        title = ::Regexp.last_match(3).strip.empty? ? type.capitalize : ::Regexp.last_match(3).strip
         text = ::Regexp.last_match(4).gsub(/^#{Regexp.escape(initial_indent)}\s*>\s*/, '').strip
-        
-        icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
-        Jekyll.logger.debug 'GFMA:', "Converting #{type} admonition."
 
+        icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
         text_with_breaks = text.chomp.gsub(/\n/, "  \n")
         admonition_html(type, title, text_with_breaks, icon)
       end
+
+      # 🛠 Ensure a blank line exists after each admonition block to prevent Markdown parsing issues.
+      doc.content.gsub!(/(<\/div>)(?!\n\n)/, "\\1\n\n")
     end
 
     def admonition_html(type, title, text, icon)

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -73,6 +73,9 @@ module JekyllGFMAdmonitions
     end
 
     def process_doc(doc)
+      # Return early if content is empty
+      return if doc.content.empty?
+
       # If the content is frozen, we need to duplicate it so that we can modify it
       doc.content = doc.content.dup unless doc.content.frozen?
 

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -96,27 +96,31 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/^\s*>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\s*>\s*[^\n]*(?:\n|$))(?:(?!\s*>\s*\[!)\s*>\s*[^\n]*(?:\n|$))*)/) do
-        type = ::Regexp.last_match(1).downcase
-        if ::Regexp.last_match(2).strip.length > 0
-          title = ::Regexp.last_match(2).strip
+      doc.content.gsub!(/^(\s*)>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1\s*>\s*[^\n]*(?:\n|$))(?:(?!\s*>\s*\[!)\1\s*>\s*[^\n]*(?:\n|$))*)/) do
+        initial_indent = ::Regexp.last_match(1)
+        type = ::Regexp.last_match(2).downcase
+        if ::Regexp.last_match(3).strip.length > 0
+          title = ::Regexp.last_match(3).strip
         else
           title = type.capitalize
         end
-        text = ::Regexp.last_match(3).gsub(/^>\s*/, '').strip
+        
+        # Remove the consistent indentation and blockquote markers from each line
+        text = ::Regexp.last_match(4).gsub(/^#{Regexp.escape(initial_indent)}\s*>\s*/, '').strip
+        
         icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
         Jekyll.logger.debug 'GFMA:', "Converting #{type} admonition."
 
-        text_with_breaks = text.chomp.gsub(/\n/, "  \n")  # Remove trailing newline and add two spaces before remaining newlines
+        text_with_breaks = text.chomp.gsub(/\n/, "  \n")
         admonition_html(type, title, text_with_breaks, icon)
       end
     end
 
     def admonition_html(type, title, text, icon)
-      "<div class='markdown-alert markdown-alert-#{type}'>
-          <p class='markdown-alert-title'>#{icon} #{title}</p>
-          <p>#{@markdown.convert(text)}</p>
-        </div>\n\n"
+      "<div class='markdown-alert markdown-alert-#{type}'>" \
+        "<p class='markdown-alert-title'>#{icon} #{title}</p>" \
+        "#{@markdown.convert(text)}" \
+      "</div>"
     end
   end
 

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -103,8 +103,7 @@ module JekyllGFMAdmonitions
         text = ::Regexp.last_match(4).gsub(/^#{Regexp.escape(initial_indent)}\s*>\s*/, '').strip
 
         icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
-        text_with_breaks = text.chomp.gsub(/\n/, "  \n")
-        admonition_html(type, title, text_with_breaks, icon)
+        admonition_html(type, title, text, icon)
       end
 
       # 🛠 Ensure a blank line exists after each admonition block to prevent Markdown parsing issues.

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -96,10 +96,10 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]\s*(.*)\s*\n((?:>.*\n?)*)/) do
+      doc.content.gsub!(/>\s*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:>.*\n?)*)/) do
         type = ::Regexp.last_match(1).downcase
-        if ::Regexp.last_match(2).length > 0
-          title = ::Regexp.last_match(2)
+        if ::Regexp.last_match(2).strip.length > 0
+          title = ::Regexp.last_match(2).strip
         else
           title = type.capitalize
         end


### PR DESCRIPTION
If the doc content is an empty string, then by default the string is Frozen and `gsub!` fails. This fixes that by exiting early if the content is empty. Also tests if the content is frozen before running `gsub!`

This fixes an error where Jekyll builds fail with an error: `jekyll 3.10.0 | Error:  can't modify frozen String: ""`

This PR also fixes a few other issues:

```markdown
> [!NOTE]
> Multi-line
> admonitions should render with <br /> tags for newlines

  > [!NOTE]
  > Indented admonitions are allowed
  > Like this one.

 > [!WARNING]
 > Headings after admonitions continue to work
 
 ### Like this one
 
 It's tricky.
 ```
 
 Should render:
 
 > [!NOTE]
> Multi-line
> admonitions should render with <br /> tags for newlines

  > [!NOTE]
  > Indented admonitions are allowed
  > Like this one.

 > [!WARNING]
 > Headings after admonitions continue to work
 
 ### Like this one
 
 It's tricky.