### PR TITLE
fix #20: preserve nested list indentation inside admonitions

### DIFF
--- a/jekyll-gfm-admonitions.gemspec
+++ b/jekyll-gfm-admonitions.gemspec
@@ -4,7 +4,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'jekyll-gfm-admonitions'
-  spec.version       = '1.4.2'
+  spec.version       = '1.4.3'
   spec.authors       = ['Robin De Schepper']
   spec.email         = ['robin.deschepper93@gmail.com']
 

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -137,7 +137,11 @@ module JekyllGFMAdmonitions
         initial_indent = ::Regexp.last_match(1)
         type = ::Regexp.last_match(2).downcase
         title = ::Regexp.last_match(3).strip.empty? ? type.capitalize : ::Regexp.last_match(3).strip
-        text = ::Regexp.last_match(4).gsub(/^#{Regexp.escape(initial_indent)}[^\S\n]*>[^\S\n]*/, '').strip
+        # Strip the blockquote prefix from each line. Per CommonMark, a `>`
+        # marker consumes at most ONE following space, so we only remove a
+        # single space here. Consuming all whitespace would flatten the
+        # indentation that distinguishes nested list items (see issue #20).
+        text = ::Regexp.last_match(4).gsub(/^#{Regexp.escape(initial_indent)}[^\S\n]*>[^\S\n]?/, '').strip
 
         icon = Octicons::Octicon.new(ADMONITION_ICONS[type]).to_svg
         html = admonition_html(type, title, text, icon)

--- a/spec/jekyll_gfm_admonitions_spec.rb
+++ b/spec/jekyll_gfm_admonitions_spec.rb
@@ -184,6 +184,49 @@ RSpec.describe JekyllGFMAdmonitions::GFMAdmonitionConverter do
       expect(doc.content).to include('line one')
       expect(doc.content).to include('line two')
     end
+
+    # Regression test for issue #20: nested (second-hierarchy) bullet points
+    # inside an admonition were flattened to the first hierarchy because the
+    # blockquote-stripping regex consumed *all* whitespace after `>` instead of
+    # the single space a `>` marker is allowed to consume.
+    it 'preserves nested list indentation when stripping blockquote markers' do
+      received = nil
+      allow(markdown_converter).to receive(:convert) do |text|
+        received = text
+        "<p>#{text}</p>"
+      end
+      doc = doc_with(
+        "> [!NOTE]\n" \
+        "> Some text\n" \
+        "> - `templates/`\n" \
+        ">   - `generateBuilders.mustache`\n" \
+        ">   - `pojo.mustache`\n"
+      )
+      converter.send(:convert_admonitions, doc)
+      expect(received).to eq(
+        "Some text\n" \
+        "- `templates/`\n" \
+        "  - `generateBuilders.mustache`\n" \
+        "  - `pojo.mustache`"
+      )
+    end
+
+    it 'preserves nested list indentation for admonitions inside list items' do
+      received = nil
+      allow(markdown_converter).to receive(:convert) do |text|
+        received = text
+        "<p>#{text}</p>"
+      end
+      # 3-space indent (e.g. inside an ordered list item) before the `>` marker.
+      doc = doc_with(
+        "1. item\n\n" \
+        "   > [!NOTE]\n" \
+        "   > - parent\n" \
+        "   >   - child\n"
+      )
+      converter.send(:convert_admonitions, doc)
+      expect(received).to eq("- parent\n  - child")
+    end
   end
 
   # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #20 — second-hierarchy bullet points inside a `> [!NOTE]` (or any admonition) block were flattened to the first hierarchy.

## Root cause

When stripping the `>` blockquote prefix from each body line, the regex consumed **all** leading whitespace after `>` (`[^\S\n]*`), discarding the indentation that distinguishes nested list items:

```
> - `templates/`
>   - `generateBuilders.mustache`   ->  both items ended up at column 0
```

## Fix

Per CommonMark, a `>` marker consumes at most a **single** following space. The regex now strips only one space (`[^\S\n]?`), keeping the relative indentation of nested lists intact while still trimming the standard one-space prefix.

## Tests

Added two regression tests (top-level admonition and list-item-indented admonition) that assert nested list indentation is preserved in the body handed to the markdown converter. Full suite: **28 examples, 0 failures**.

Bumps version to **1.4.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)