### PR TITLE
feat: allow case-insensitive admonitions

### DIFF
--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -133,7 +133,7 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/^([^\S\n]*)>[^\S\n]*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))(?:(?![^\S\n]*>[^\S\n]*\[!)\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))*)/) do
+      doc.content.gsub!(/^([^\S\n]*)>[^\S\n]*\[!(?i:IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))(?:(?![^\S\n]*>[^\S\n]*\[!)\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))*)/) do
         initial_indent = ::Regexp.last_match(1)
         type = ::Regexp.last_match(2).downcase
         title = ::Regexp.last_match(3).strip.empty? ? type.capitalize : ::Regexp.last_match(3).strip


### PR DESCRIPTION
- Allows case-insensitive admonitions, just like in native Github.

```md
> [!note]
> This is a note. The tag is all lowercase
```
works natively; it does not need to be all caps not case-sensitive.
> [!note]
> This is a note. The tag is all lowercase.

```md
> [!WarnIng]
> This is a warning. The tag is mixed-case.
```

> [!WarnIng]
> This is a warning. The tag is mixed-case.