### PR TITLE
fix #23: allow case-insensitive admonition tags

### DIFF
--- a/jekyll-gfm-admonitions.gemspec
+++ b/jekyll-gfm-admonitions.gemspec
@@ -4,7 +4,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'jekyll-gfm-admonitions'
-  spec.version       = '1.4.3'
+  spec.version       = '1.4.4'
   spec.authors       = ['Robin De Schepper']
   spec.email         = ['robin.deschepper93@gmail.com']
 

--- a/lib/jekyll-gfm-admonitions.rb
+++ b/lib/jekyll-gfm-admonitions.rb
@@ -133,7 +133,7 @@ module JekyllGFMAdmonitions
     end
 
     def convert_admonitions(doc)
-      doc.content.gsub!(/^([^\S\n]*)>[^\S\n]*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))(?:(?![^\S\n]*>[^\S\n]*\[!)\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))*)/) do
+      doc.content.gsub!(/^([^\S\n]*)>[^\S\n]*\[!(IMPORTANT|NOTE|WARNING|TIP|CAUTION)\]([^\n]*)\n((?:\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))(?:(?![^\S\n]*>[^\S\n]*\[!)\1[^\S\n]*>[^\S\n]*[^\n]*(?:\n|$))*)/i) do
         initial_indent = ::Regexp.last_match(1)
         type = ::Regexp.last_match(2).downcase
         title = ::Regexp.last_match(3).strip.empty? ? type.capitalize : ::Regexp.last_match(3).strip

--- a/spec/jekyll_gfm_admonitions_spec.rb
+++ b/spec/jekyll_gfm_admonitions_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe JekyllGFMAdmonitions::GFMAdmonitionConverter do
     end
 
     # -----------------------------------------------------------------------
+    # Case-insensitive tags (issue #23) — GitHub treats [!note], [!WarnIng]
+    # the same as their uppercase forms.
+    # -----------------------------------------------------------------------
+
+    {
+      'note' => 'note',
+      'WarnIng' => 'warning',
+      'Tip' => 'tip',
+      'iMpOrTaNt' => 'important',
+      'caution' => 'caution'
+    }.each do |tag, type|
+      it "renders the mixed/lower-case tag [!#{tag}] as a #{type} admonition" do
+        doc = doc_with("> [!#{tag}]\n> body\n")
+        converter.send(:process_doc, doc)
+        expect(doc.content).to include("markdown-alert-#{type}")
+      end
+    end
+
+    # -----------------------------------------------------------------------
     # Code blocks are restored exactly
     # -----------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #23.

## Problem
GitHub renders admonition tags case-insensitively (e.g. `[!note]`, `[!WarnIng]`), but this plugin only matched the uppercase forms `IMPORTANT|NOTE|WARNING|TIP|CAUTION`, leaving lower/mixed-case tags unconverted.

## Fix
Add the `/i` flag to the admonition-matching regex in `lib/jekyll-gfm-admonitions.rb`. The captured `type` is already `.downcase`d before it is used for the icon lookup and CSS class, so lower/mixed-case tags now resolve to the correct admonition type with no other changes.

## Tests
Adds a regression test covering `[!note]`, `[!WarnIng]`, `[!Tip]`, `[!iMpOrTaNt]`, and `[!caution]`. Full suite green (33 examples, 0 failures).

Version bumped to **1.4.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)